### PR TITLE
Backport CFFI fix for Aclima IoT SDK

### DIFF
--- a/meta-python/recipes-devtools/python/python-cffi.inc
+++ b/meta-python/recipes-devtools/python/python-cffi.inc
@@ -10,6 +10,7 @@ SRC_URI[sha256sum] = "041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744
 RDEPENDS_${PN}_class-target = " \
     ${PYTHON_PN}-ctypes \
     ${PYTHON_PN}-io \
+    ${PYTHON_PN}-pycparser \
     ${PYTHON_PN}-shell \
 "
 


### PR DESCRIPTION
## Description

This PR backports a fix applied to upstream `master`, but not backported to the `warrior` branch: https://github.com/openembedded/meta-openembedded/commit/09a2a684eb7e38c2f6da69fdfd5363e971528316

@igor47:

CFFI may not seem like a dependency of IoT SDK, but setup.py defines `entry_points` here: https://github.com/Aclima/iot-sdk-py/blob/1a845eb/setup.py#L41-L43. Entry points require setuptools available at runtime to locate themselves. setuptools depends on CFFI for unrelated stuff. CFFI depends on cparser. So when cparser is not present, running IoT SDK fails. Welcome to the dependency hell that is my life.

@jpao79, @mikevoyt, @photon2016:

Currently, sundstrom-os relies on the moving `warrior` branch of upstream meta-openembedded: https://github.com/Aclima/sundstrom-os/blob/cf4e54dd9cdb13653176a75db4cf402bf06c4e1d/default.xml#L12

You'll notice that openembedded-core is forked to my personal account. This is because it has required several modifications against the current upstream that it's tracking: https://github.com/eigendude/openembedded-core/pulls?q=is%3Apr+is%3Aclosed

Now that meta-openembedded requires a modification (at least until we leave `warrior`), it's being set to my personal repo too. As an advantage, we now control when critical security fixes are backported, so we're not surprised like the breakage due to the ZMQ vulnerability that was fixed. As a disadvantage, security fixes are no longer automatic. I'm taking on the responsibility of regularly rebasing this branch. I'll communicate when I rebase, usually immediately after releases for the next develop cycle.

## How has this been tested?

Tested with the IoT SDK PR https://github.com/Aclima/meta-sundstrom/pull/29 and running:

```
aclima_iot_sdk manage.create-keys
```