### PR TITLE
Allow custom RTC filename in ntpdate

### DIFF
--- a/meta-networking/recipes-support/ntp/ntp/ntpdate
+++ b/meta-networking/recipes-support/ntp/ntp/ntpdate
@@ -42,7 +42,7 @@ fi
 
 if /usr/sbin/ntpdate -s $OPTS $NTPSERVERS 2>/dev/null; then
 	if [ "$UPDATE_HWCLOCK" = "yes" ]; then
-		hwclock --systohc || :
+		hwclock --systohc --rtc="$HWCLOCK_FILENAME" || :
 	fi
 fi
 

--- a/meta-networking/recipes-support/ntp/ntp/ntpdate.default
+++ b/meta-networking/recipes-support/ntp/ntp/ntpdate.default
@@ -5,3 +5,5 @@ NTPSERVERS=""
 # Set to "yes" to write time to hardware clock on success
 UPDATE_HWCLOCK="no"
 
+# Override the default /dev filename for the hardware clock, if set to update
+HWCLOCK_FILENAME="/dev/rtc"


### PR DESCRIPTION
## Description

This PR adds a new parameter, `HWCLOCK_FILENAME`, that lets a recipe override the RTC used by `hwclock` in the `ntpdate` script.

## How has this been tested?

TODO: Boot a device with internet and an uninitialized RTC, and check if the RTC was set.
