### PR TITLE
Launch ntpd after ntpdate has run

### DIFF
--- a/meta-networking/recipes-support/ntp/ntp/ntpd.service
+++ b/meta-networking/recipes-support/ntp/ntp/ntpd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Network Time Service
-After=network.target
+After=ntpdate.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
## Description

I encountered a conflict between `ntpd` (the daemon) and `ntpdate` (the one-shot updater). When `ntpd` is running, `ntpdate` fails because the port is in use.

To fix this, I made the `ntpd` systemd service depend on the `ntpdate` service, making it start after the one-shot updater has completed.

## How has this been tested?

Tested on a device, noticed no port-in-use errors.