### PR TITLE
Fixes for Super Flore on Yocto Warrior

### DIFF
--- a/meta-oe/recipes-devtools/yasm/yasm_git.bb
+++ b/meta-oe/recipes-devtools/yasm/yasm_git.bb
@@ -13,7 +13,7 @@ SRC_URI = "git://github.com/yasm/yasm.git"
 
 S = "${WORKDIR}/git"
 
-inherit autotools gettext pythonnative
+inherit autotools gettext python3native
 
 CACHED_CONFIGUREVARS = "CCLD_FOR_BUILD='${CC_FOR_BUILD}'"
 

--- a/meta-oe/recipes-extended/libimobiledevice/libplist_2.0.0.bb
+++ b/meta-oe/recipes-extended/libimobiledevice/libplist_2.0.0.bb
@@ -4,9 +4,9 @@ LICENSE = "GPLv2 & LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ebb5c50ab7cab4baeffba14977030c07 \
                     file://COPYING.LESSER;md5=6ab17b41640564434dda85c06b7124f7"
 
-DEPENDS = "libxml2 glib-2.0 swig python"
+DEPENDS = "libxml2 glib-2.0 swig python3"
 
-inherit autotools pkgconfig pythonnative
+inherit autotools pkgconfig python3native
 
 SRCREV = "62ec804736435fa34e37e66e228e17e2aacee1d7"
 SRC_URI = "git://github.com/libimobiledevice/libplist;protocol=https \

--- a/meta-python/recipes-devtools/python/python-pycurl.inc
+++ b/meta-python/recipes-devtools/python/python-pycurl.inc
@@ -1,0 +1,26 @@
+SUMMARY = "A Python Interface To The cURL library"
+DESCRIPTION = "\
+PycURL is a Python interface to libcurl, the multiprotocol file \
+transfer library. Similarly to the urllib Python module, PycURL can \
+be used to fetch objects identified by a URL from a Python program \
+"
+SECTION = "devel/python"
+HOMEPAGE = "http://pycurl.io/"
+
+LICENSE = "LGPLv2 | MIT"
+LIC_FILES_CHKSUM = " \
+    file://COPYING-LGPL;md5=4fbd65380cdd255951079008b364516c \
+    file://COPYING-MIT;md5=2df767ed35d8ea83de4a93feb55e7815 \
+"
+
+SRC_URI[md5sum] = "f0ed4c805e8bec734990e2e0ee78568e"
+SRC_URI[sha256sum] = "6f08330c5cf79fa8ef68b9912b9901db7ffd34b63e225dce74db56bb21deda8e"
+
+inherit pypi
+
+PYPI_PACKAGE = "pycurl"
+
+DEPENDS = "\
+    curl \
+    ${PYTHON_PN}\
+"

--- a/meta-python/recipes-devtools/python/python-pycurl_7.43.0.3.bb
+++ b/meta-python/recipes-devtools/python/python-pycurl_7.43.0.3.bb
@@ -1,0 +1,2 @@
+inherit setuptools
+require python-pycurl.inc

--- a/meta-python/recipes-devtools/python/python3-pycurl_7.43.0.3.bb
+++ b/meta-python/recipes-devtools/python/python3-pycurl_7.43.0.3.bb
@@ -1,0 +1,2 @@
+inherit setuptools3
+require python-pycurl.inc


### PR DESCRIPTION
## Description

This PR imports the `python-pycurl` package from the Yocto Zeus branch of upstream meta-openembedded. This package was removed from meta-ros, so we'll need to get it from this commit until we upgrade to Yocto Zeus.

This PR also switches the Python interpret used to build native packages from Python 2 to Python 3.

## How has this been tested?

Tested as part of https://github.com/Aclima/sundstrom-os/pull/24