### PR TITLE
Fixes for Yocto 3.0 Zeus

### DIFF
--- a/meta-oe/recipes-devtools/protobuf/protobuf_3.9.2.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf_3.9.2.bb
@@ -84,6 +84,8 @@ MIPS_INSTRUCTION_SET = "mips"
 
 BBCLASSEXTEND = "native nativesdk"
 
+CXXFLAGS_append_class-target = " -fPIC"
+
 LDFLAGS_append_arm = " -latomic"
 LDFLAGS_append_mips = " -latomic"
 LDFLAGS_append_powerpc = " -latomic"

--- a/meta-oe/recipes-devtools/yasm/yasm_git.bb
+++ b/meta-oe/recipes-devtools/yasm/yasm_git.bb
@@ -13,7 +13,7 @@ SRC_URI = "git://github.com/yasm/yasm.git"
 
 S = "${WORKDIR}/git"
 
-inherit autotools gettext pythonnative
+inherit autotools gettext python3native
 
 CACHED_CONFIGUREVARS = "CCLD_FOR_BUILD='${CC_FOR_BUILD}'"
 

--- a/meta-oe/recipes-extended/libimobiledevice/libplist_2.0.0.bb
+++ b/meta-oe/recipes-extended/libimobiledevice/libplist_2.0.0.bb
@@ -4,9 +4,9 @@ LICENSE = "GPLv2 & LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ebb5c50ab7cab4baeffba14977030c07 \
                     file://COPYING.LESSER;md5=6ab17b41640564434dda85c06b7124f7"
 
-DEPENDS = "libxml2 glib-2.0 swig python"
+DEPENDS = "libxml2 glib-2.0 swig python3"
 
-inherit autotools pkgconfig pythonnative
+inherit autotools pkgconfig python3native
 
 SRCREV = "62ec804736435fa34e37e66e228e17e2aacee1d7"
 SRC_URI = "git://github.com/libimobiledevice/libplist;protocol=https \

--- a/meta-python/recipes-devtools/python/python-protobuf.inc
+++ b/meta-python/recipes-devtools/python/python-protobuf.inc
@@ -7,6 +7,10 @@ LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=19e8f490f9526b1de8
 
 inherit pypi
 
+SRC_URI += " \
+    file://0001-setup.cfg-Change-location-of-statically-linked-libra.patch \
+"
+
 SRC_URI[md5sum] = "d634666c898148e4565ac62f3ba4a2ca"
 SRC_URI[sha256sum] = "843f498e98ad1469ad54ecb4a7ccf48605a1c5d2bd26ae799c7a2cddab4a37ec"
 

--- a/meta-python/recipes-devtools/python/python-protobuf/0001-setup.cfg-Change-location-of-statically-linked-libra.patch
+++ b/meta-python/recipes-devtools/python/python-protobuf/0001-setup.cfg-Change-location-of-statically-linked-libra.patch
@@ -1,0 +1,28 @@
+From d99244cf587c360f2ec2a5e8da90a0fa5ce510ad Mon Sep 17 00:00:00 2001
+From: Garrett Brown <garrett.brown@aclima.io>
+Date: Tue, 26 Nov 2019 18:18:43 -0800
+Subject: [PATCH] setup.cfg: Change location of statically-linked libraries
+
+TODO: Pass library directory from BitBake.
+---
+ setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 9aabbf7..9152264 100755
+--- a/setup.py
++++ b/setup.py
+@@ -174,8 +174,8 @@ if __name__ == '__main__':
+     extra_objects = None
+     if compile_static_ext:
+       libraries = None
+-      extra_objects = ['../src/.libs/libprotobuf.a',
+-                       '../src/.libs/libprotobuf-lite.a']
++      extra_objects = ['../recipe-sysroot/usr/lib/libprotobuf.a',
++                       '../recipe-sysroot/usr/lib/libprotobuf-lite.a']
+     test_conformance.target = 'test_python_cpp'
+ 
+     extra_compile_args = []
+-- 
+2.20.1
+

--- a/meta-python/recipes-devtools/python/python3-colorama_0.4.1.bb
+++ b/meta-python/recipes-devtools/python/python3-colorama_0.4.1.bb
@@ -8,3 +8,4 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "f927529cd1735f6f50ee2c61628e9c1f"
 SRC_URI[sha256sum] = "05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"
 
+BBCLASSEXTEND += "native"

--- a/meta-python/recipes-devtools/python/python3-protobuf_3.9.2.bb
+++ b/meta-python/recipes-devtools/python/python3-protobuf_3.9.2.bb
@@ -1,8 +1,10 @@
 inherit setuptools3
 require python-protobuf.inc
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/python-protobuf:"
+
 DEPENDS += "protobuf"
-DISTUTILS_BUILD_ARGS += "--cpp_implementation"
+DISTUTILS_BUILD_ARGS += "--cpp_implementation --compile_static_extension"
 DISTUTILS_INSTALL_ARGS += "--cpp_implementation"
 
 do_compile_prepend_class-native () {


### PR DESCRIPTION
## Description

This PR provides several fixes when using our stacks with Yocto Zeus. The fixes fall in two categories:

#### Build fixes
* Fix build error with Colorama

#### Runtime fixes
* Statically compile and link libprotobuf

#### Python 2 EOL
* Use Python 3 to build libplist
* Use Python 3 to build Yasm

## How has this been tested?

Tested as part of https://github.com/Aclima/sundstrom-os/pull/25